### PR TITLE
Allows single quote in the originator

### DIFF
--- a/MessageBird/Utilities/Validation.cs
+++ b/MessageBird/Utilities/Validation.cs
@@ -50,7 +50,7 @@ namespace MessageBird.Utilities
             if (!string.IsNullOrEmpty(originator))
             {
                 var numeric = new Regex("^\\+?[0-9]+$");
-                var alphanumericWithWhitespace = new Regex("^[A-Za-z0-9]+(?:\\s[A-Za-z0-9]+)*$");
+                var alphanumericWithWhitespace = new Regex("^['A-Za-z0-9]+(?:\\s['A-Za-z0-9]+)*$");
                 var isNumeric = numeric.IsMatch(originator);
                 var isAlphanumericWithWhitespace = alphanumericWithWhitespace.IsMatch(originator);
 


### PR DESCRIPTION
We know that messagebird allows single quotes in the originator, we managed to send text messages from the website with originator name containing a single quote.
We would like to have the same ability from the SDK.