### PR TITLE
Added support for request timeout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -230,3 +230,4 @@ _Pvt_Extensions
 
 # FAKE - F# Make
 .fake/
+/.nuget/nuget.exe

--- a/MessageBird/Client.cs
+++ b/MessageBird/Client.cs
@@ -11,6 +11,12 @@ namespace MessageBird
     {
         private readonly IRestClient restClient;
 
+        public TimeSpan RequestTimeout
+        {
+            get { return restClient.RequestTimeout; }
+            set { restClient.RequestTimeout = value; }
+        }
+
         private Client(IRestClient restClient)
         {
             this.restClient = restClient;

--- a/MessageBird/Net/IRestClient.cs
+++ b/MessageBird/Net/IRestClient.cs
@@ -1,5 +1,6 @@
 ﻿using MessageBird.Net.ProxyConfigurationInjector;
 using MessageBird.Resources;
+using System;
 
 namespace MessageBird.Net
 {
@@ -9,6 +10,7 @@ namespace MessageBird.Net
         string AccessKey { get; }
         string Endpoint { get; }
         IProxyConfigurationInjector ProxyConfigurationInjector { get; }
+        TimeSpan RequestTimeout { get; set; }
 
         string ApiVersion { get; }
         string ClientVersion { get; }

--- a/MessageBird/Net/RestClient.cs
+++ b/MessageBird/Net/RestClient.cs
@@ -20,6 +20,8 @@ namespace MessageBird.Net
 
         public IProxyConfigurationInjector ProxyConfigurationInjector { get; private set; }
 
+        public TimeSpan RequestTimeout { get; set; }
+
         public string ClientVersion
         {
             get { return "1.0"; }
@@ -35,15 +37,26 @@ namespace MessageBird.Net
             get { return string.Format("MessageBird/ApiClient/{0} DotNet/{1}", ApiVersion, ClientVersion); }
         }
 
-        public RestClient(string endpoint, string accessKey, IProxyConfigurationInjector proxyConfigurationInjector)
+        public RestClient(string endpoint, string accessKey, IProxyConfigurationInjector proxyConfigurationInjector, TimeSpan requestTimeout)
         {
             Endpoint = endpoint;
             AccessKey = accessKey;
             ProxyConfigurationInjector = proxyConfigurationInjector;
+            RequestTimeout = requestTimeout;
+        }
+
+        public RestClient(string endpoint, string accessKey, IProxyConfigurationInjector proxyConfigurationInjector)
+            : this(endpoint, accessKey, proxyConfigurationInjector, TimeSpan.FromSeconds(60))
+        {
+        }
+
+        public RestClient(string accessKey, IProxyConfigurationInjector proxyConfigurationInjector, TimeSpan requestTimeout)
+            : this(HttpsRestMessagebirdComEndpoint, accessKey, proxyConfigurationInjector, requestTimeout)
+        {
         }
 
         public RestClient(string accessKey, IProxyConfigurationInjector proxyConfigurationInjector)
-            : this(HttpsRestMessagebirdComEndpoint, accessKey, proxyConfigurationInjector)
+            : this(accessKey, proxyConfigurationInjector, TimeSpan.FromSeconds(60))
         {
         }
 
@@ -137,6 +150,7 @@ namespace MessageBird.Net
             request.Accept = ApplicationJsonContentType;
             request.ContentType = ApplicationJsonContentType;
             request.Method = method;
+            request.Timeout = RequestTimeout > TimeSpan.Zero ? (int)RequestTimeout.TotalMilliseconds : 60000;
 
             WebHeaderCollection headers = request.Headers;
             headers.Add("Authorization", String.Format("AccessKey {0}", AccessKey));

--- a/csharp-rest-client.sln
+++ b/csharp-rest-client.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+# Visual Studio 15
+VisualStudioVersion = 15.0.27428.2015
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MessageBird", "MessageBird\MessageBird.csproj", "{C49CD3F8-BCDB-4BA9-B817-6A6C65452510}"
 EndProject
@@ -12,14 +12,11 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{25EE7FD1-9433-4EEE-99F3-A8344DF7AC6F}"
 	ProjectSection(SolutionItems) = preProject
 		.nuget\NuGet.Config = .nuget\NuGet.Config
-		.nuget\NuGet.exe = .nuget\NuGet.exe
+		.nuget\nuget.exe = .nuget\nuget.exe
 		.nuget\NuGet.targets = .nuget\NuGet.targets
 	EndProjectSection
 EndProject
 Global
-	GlobalSection(CodealikeProperties) = postSolution
-		SolutionGuid = 18c1a31e-4063-4902-9aad-882f3cfab5d4
-	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
@@ -40,5 +37,11 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {C59D1B5F-9D00-477F-BD73-FC2D4B0A3F0A}
+	EndGlobalSection
+	GlobalSection(CodealikeProperties) = postSolution
+		SolutionGuid = 18c1a31e-4063-4902-9aad-882f3cfab5d4
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Currently the webrequest object (.net object used to make the actual api calls) does not have a request timeout explicitly set, thus using the default timeout of 60 seconds. However, for many calls this is too much, especially when a service using the client itself uses a smaller timeout. This PR makes it possible to configure this request timeout on a Client object.