### PR TITLE
Download NuGet binary if needed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -230,3 +230,6 @@ _Pvt_Extensions
 
 # FAKE - F# Make
 .fake/
+
+# NuGet binary
+.nuget/NuGet.exe

--- a/.nuget/NuGet.targets
+++ b/.nuget/NuGet.targets
@@ -13,7 +13,7 @@
         <RequireRestoreConsent Condition=" '$(RequireRestoreConsent)' != 'false' ">true</RequireRestoreConsent>
 
         <!-- Download NuGet.exe if it does not already exist -->
-        <DownloadNuGetExe Condition=" '$(DownloadNuGetExe)' == '' ">false</DownloadNuGetExe>
+        <DownloadNuGetExe Condition=" '$(DownloadNuGetExe)' == '' ">true</DownloadNuGetExe>
     </PropertyGroup>
 
     <ItemGroup Condition=" '$(PackageSources)' == '' ">


### PR DESCRIPTION
When installing, Nuget wil look for `.nuget/NuGet.exe` and fail if it doesn't find it in that location. This PR makes sure it is downloaded when it's not found.

See also: https://stackoverflow.com/a/20502049/3521243