### PR TITLE
Target .net 4.5 and enable tls 1.2 connections

### DIFF
--- a/MessageBird/MessageBird.csproj
+++ b/MessageBird/MessageBird.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net40;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net45;net40;netstandard2.0</TargetFrameworks>
     <Product>MessageBird</Product>
     <Title>MessageBird</Title>
     <Company>MessageBird</Company>

--- a/MessageBird/Net/RestClient.cs
+++ b/MessageBird/Net/RestClient.cs
@@ -257,6 +257,9 @@ namespace MessageBird.Net
             // TODO: ##jwp; need to find out why .NET 4.0 under VS2013 refuses to recognize `WebRequest.CreateHttp`.
             // HttpWebRequest request = WebRequest.CreateHttp(uri);
             var request = WebRequest.Create(uri) as HttpWebRequest;
+            #if NET45
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls;
+            #endif
             request.UserAgent = UserAgent;
             const string ApplicationJsonContentType = "application/json"; // http://tools.ietf.org/html/rfc4627
             request.Accept = ApplicationJsonContentType;


### PR DESCRIPTION
Disabling tls 1.1 on the client system triggers this error:
The underlying connection was closed: An unexpected error occurred on a receive

Targetting .net 4.5 and enabling tls 1.2 in the code fixes this issue.