### PR TITLE
BREAKING CHANGE: Bump version to 3.0.

### DIFF
--- a/MessageBird/MessageBird.csproj
+++ b/MessageBird/MessageBird.csproj
@@ -5,10 +5,10 @@
     <Title>MessageBird</Title>
     <Company>MessageBird</Company>
     <Copyright>Copyright © 2019</Copyright>
-    <FileVersion>2.1.0.0</FileVersion>
-    <InformationalVersion>2.1.0.0</InformationalVersion>
-    <Version>2.1.0.0</Version>
-    <AssemblyVersion>2.1.0.0</AssemblyVersion>
+    <FileVersion>3.0.0.0</FileVersion>
+    <InformationalVersion>3.0.0.0</InformationalVersion>
+    <Version>3.0.0.0</Version>
+    <AssemblyVersion>3.0.0.0</AssemblyVersion>
     <LangVersion>4</LangVersion>
   </PropertyGroup>
 

--- a/MessageBird/MessageBird.csproj.nuspec
+++ b/MessageBird/MessageBird.csproj.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>MessageBird</id>
     <title>MessageBird's REST API for C#</title>
-    <version>2.1.0.0</version>
+    <version>3.0.0.0</version>
     <authors>MessageBird,Remco Vermeulen</authors>
     <owners>MessageBird</owners>
     <licenseUrl>https://github.com/messagebird/csharp-rest-api/blob/master/LICENSE</licenseUrl>

--- a/MessageBird/Net/RestClient.cs
+++ b/MessageBird/Net/RestClient.cs
@@ -19,7 +19,7 @@ namespace MessageBird.Net
 
         public string ClientVersion
         {
-            get { return "2.1.0.0"; }
+            get { return "3.0.0.0"; }
         }
 
         public string ApiVersion


### PR DESCRIPTION
This is a breaking change because it removes support for the
EnableWhatsAppSandboxConversations flag (and just overall the
ability to pass "Features" to a Client).
The Conversations API now properly supports the Sandbox, so users
who wish to send messages over the WhatsApp sandbox can simply
remove their usage of EnableWhatsAppSandboxConversations; they
only need to provide the correct channel ID for the sandbox