### PR TITLE
Add the options "unavailable" and "not_verified" to the ChannelStatus enum

### DIFF
--- a/MessageBird/Objects/Conversations/Channel.cs
+++ b/MessageBird/Objects/Conversations/Channel.cs
@@ -21,6 +21,10 @@ namespace MessageBird.Objects.Conversations
         Inactive,
         [EnumMember(Value = "pending")]
         Pending,
+        [EnumMember(Value = "not_verified")]
+        NotVerified,
+        [EnumMember(Value = "unavailable")]
+        Unavailable,
     }
     public class Channel : IIdentifiable<string>
     {


### PR DESCRIPTION
Fix for issue #99 