### PR TITLE
Support new webhook signature validation method

### DIFF
--- a/MessageBird/Exceptions/RequestValidationException.cs
+++ b/MessageBird/Exceptions/RequestValidationException.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace MessageBird.Exceptions
+{
+    public class RequestValidationException : Exception
+    {
+        public RequestValidationException(string message) : base(message) { }
+        public RequestValidationException(string message, Exception inner) : base(message, inner) { }
+    }
+}

--- a/MessageBird/MessageBird.csproj
+++ b/MessageBird/MessageBird.csproj
@@ -17,9 +17,16 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="JWT" Version="8.2.3" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Objects\Common\" />
   </ItemGroup>
+  
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>MessageBirdUnitTests</_Parameter1>
+    </AssemblyAttribute>
+</ItemGroup>
 </Project>

--- a/MessageBird/MessageBird.csproj.nuspec
+++ b/MessageBird/MessageBird.csproj.nuspec
@@ -14,6 +14,7 @@
     <tags>SMS MMS OTP 2FA Voice MessageBird Telecom</tags>
     <dependencies>
       <group>
+        <dependency id="JWT" version="8.2.3" />
         <dependency id="Newtonsoft.Json" version="9.0.1" />
       </group>
     </dependencies>

--- a/MessageBird/Objects/Request.cs
+++ b/MessageBird/Objects/Request.cs
@@ -11,7 +11,6 @@ namespace MessageBird.Objects
      *  * and request body
      *
      * @see more on https://developers.messagebird.com/docs/verify-http-requests 
-     * @deprecated 
      */
     [Obsolete("Use RequestValidator instead.", false)]
     public class Request
@@ -30,7 +29,7 @@ namespace MessageBird.Objects
          * @param queryParameters Query parameters in abc=foo&def=ghi format.
          * @param data Raw body of this request.
          */
-         [Obsolete("Use RequestValidator instead.", false)]
+        [Obsolete("Use RequestValidator instead.", false)]
         public Request(string timestamp, string queryParameters, byte[] data) {
             if (string.IsNullOrEmpty(timestamp)) {
                 throw new ArgumentNullException("timestamp");

--- a/MessageBird/Objects/Request.cs
+++ b/MessageBird/Objects/Request.cs
@@ -11,7 +11,9 @@ namespace MessageBird.Objects
      *  * and request body
      *
      * @see more on https://developers.messagebird.com/docs/verify-http-requests 
+     * @deprecated 
      */
+    [Obsolete("Use RequestValidator instead.", false)]
     public class Request
     {
         internal string Timestamp { get; private set; }
@@ -28,6 +30,7 @@ namespace MessageBird.Objects
          * @param queryParameters Query parameters in abc=foo&def=ghi format.
          * @param data Raw body of this request.
          */
+         [Obsolete("Use RequestValidator instead.", false)]
         public Request(string timestamp, string queryParameters, byte[] data) {
             if (string.IsNullOrEmpty(timestamp)) {
                 throw new ArgumentNullException("timestamp");
@@ -37,8 +40,8 @@ namespace MessageBird.Objects
             QueryParameters = queryParameters;
             Data = data;
         }
-        
-        
+
+
         internal string SortedQueryParameters() {
             var queryParams = QueryParameters.Split(QueryParametersDelimiter);
             Array.Sort(queryParams);

--- a/MessageBird/RequestSigner.cs
+++ b/MessageBird/RequestSigner.cs
@@ -6,10 +6,11 @@ using MessageBird.Objects;
 
 namespace MessageBird
 {
+    [Obsolete("Use RequestValidator instead", false)]
     public class RequestSigner
     {
         private readonly byte[] _secret;
-        
+
         /**
          * Constructs a new RequestSigner instance.
          *
@@ -19,12 +20,13 @@ namespace MessageBird
          *
          * @see https://developers.messagebird.com/docs/verify-http-requests
          */
+        [Obsolete("Use RequestValidator instead", false)]
         public RequestSigner(byte[] secret)
         {
             _secret = secret;
         }
 
-        
+
         /**
          * Computes the signature for the provided request and determines whether
          * it matches the expected signature (from the raw MessageBird-Signature header).
@@ -34,6 +36,7 @@ namespace MessageBird
          * @param request Request containing the values from the incoming webhook.
          * @return True if the computed signature matches the expected signature.
          */
+        [Obsolete("Use RequestValidator instead", false)]
         public bool IsMatch(string encodedSignature, Request request)
         {
             using (var base64Transform = new FromBase64Transform())
@@ -44,7 +47,7 @@ namespace MessageBird
                 return IsMatch(decodedSignature, request);
             }
         }
-        
+
         /**
          * Computes the signature for the provided request and determines whether
          * it matches the expected signature
@@ -54,6 +57,7 @@ namespace MessageBird
          * @param request Request containing the values from the incoming webhook.
          * @return True if the computed signature matches the expected signature.
          */
+        [Obsolete("Use RequestValidator instead", false)]
         public bool IsMatch(byte[] expectedSignature, Request request)
         {
             var actualSignature = ComputeSignature(request);
@@ -66,15 +70,16 @@ namespace MessageBird
          * @param request Request to compute signature for.
          * @return HMAC-SHA2556 signature for the provided request.
          */
-        private byte[] ComputeSignature(Request request) {
+        private byte[] ComputeSignature(Request request)
+        {
             var timestampAndQuery = request.Timestamp + '\n' + request.SortedQueryParameters() + '\n';
             var timestampAndQueryBytes = Encoding.UTF8.GetBytes(timestampAndQuery);
             var bodyHashBytes = SHA256.Create().ComputeHash(request.Data);
-            
+
             var signPayload = new byte[timestampAndQueryBytes.Length + bodyHashBytes.Length];
             Array.Copy(timestampAndQueryBytes, signPayload, timestampAndQueryBytes.Length);
             Array.Copy(bodyHashBytes, 0, signPayload, timestampAndQueryBytes.Length, bodyHashBytes.Length);
-            
+
             return new HMACSHA256(_secret).ComputeHash(signPayload, 0, signPayload.Length);
         }
     }

--- a/MessageBird/RequestValidator.cs
+++ b/MessageBird/RequestValidator.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Text;
+using JWT;
+using JWT.Builder;
+using MessageBird.Exceptions;
+
+namespace MessageBird
+{
+    /// <summary>
+    /// Class RequestValidator validates request signature signed by MessageBird services.
+    /// </summary>
+    ///
+    /// <see href="https://developers.messagebird.com/docs/verify-http-requests" />
+    public class RequestValidator
+    {
+        private readonly JwtBuilder _jwtBuilder;
+
+        /// <summary>
+        /// This field instructs Validator to not validate url_hash claim.
+        /// It is recommended to not skip URL validation to ensure high security.
+        /// but the ability to skip URL validation is necessary in some cases, e.g.
+        /// your service is behind proxy or when you want to validate it yourself.
+        /// Note that when true, no query parameters should be trusted.
+        /// Defaults to false.
+        /// </summary>
+        private readonly bool _skipURLValidation;
+
+        /// <summary>
+        /// This constructor initializes a new RequestValidator instance.
+        /// </summary>
+        ///
+        /// <param name="secret">signing key. Can be retrieved from https://dashboard.messagebird.com/developers/settings. This is NOT your API key.</param>
+        /// <param name="skipURLValidation">whether url_hash claim validation should be skipped. Note that when true, no query parameters should be trusted.</param>
+        /// <see href="https://developers.messagebird.com/docs/verify-http-requests" />
+        public RequestValidator(string secret, bool skipURLValidation = false)
+        {
+            _jwtBuilder = JwtBuilder.Create()
+                     .WithAlgorithmFactory(new JWT.Algorithms.HMACSHAAlgorithmFactory())
+                     .WithSecret(secret)
+                     .MustVerifySignature();
+            _skipURLValidation = skipURLValidation;
+        }
+
+        /// <summary>
+        /// Internal constructor visible for unit testing.
+        /// </summary>
+        internal RequestValidator(string secret, IDateTimeProvider dateTimeProvider) : this(secret)
+        {
+            _jwtBuilder = _jwtBuilder.WithDateTimeProvider(dateTimeProvider);
+        }
+
+        /// <summary>
+        /// Validate JWT signature.
+        /// This JWT is signed with a MessageBird account unique secret key, ensuring the request is from MessageBird and a specific account.
+        /// The JWT contains the following claims:
+        /// <list type="bullet">
+        ///     <item>
+        ///         <term>url_hash</term>
+        ///         <description>the raw URL hashed with SHA256 ensuring the URL wasn't altered.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>payload_hash</term>
+        ///         <description>the raw payload hashed with SHA256 ensuring the payload wasn't altered.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>jti</term>
+        ///         <description>a unique token ID to implement an optional non-replay check (NOT validated by default).</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>nbf</term>
+        ///         <description>the not before timestamp.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>exp</term>
+        ///         <description>the expiration timestamp is ensuring that a request isn't captured and used at a later time.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>iss</term>
+        ///         <description>the issuer name, always MessageBird.</description>
+        ///     </item>
+        /// </list>
+        /// </summary>
+        /// 
+        /// <param name="signature">request signature taken from request header MessageBird-Signature-JWT.</param>
+        /// <param name="url">full URL of the receiving endpoint, including scheme, host, path and query.</param>
+        /// <param name="body">request body.</param>
+        /// <returns>A dictionary representing decoded JWT signature token claims</returns>
+        /// <exception cref="RequestValidationException">Throws if signature can not be verified.</exception>
+        public IDictionary<string, string> ValidateSignature(string signature, string url, byte[] body)
+        {
+            IDictionary<string, string> payload;
+            try
+            {
+                payload = _jwtBuilder.Decode<IDictionary<string, string>>(signature);
+            }
+            catch (Exception e)
+            {
+                throw new RequestValidationException(e.Message, e);
+            }
+
+            string[] requiredClaims = { "iss", "nbf", "exp" };
+            foreach (string claim in requiredClaims)
+            {
+                if (payload.ContainsKey(claim)) continue;
+                throw new RequestValidationException(String.Format("invalid jwt: claim {0} is missing", claim));
+            }
+
+            if (!payload["iss"].Equals("MessageBird"))
+            {
+                throw new RequestValidationException("invalid jwt: claim iss has wrong value");
+            }
+
+            if (!_skipURLValidation)
+            {
+                string expectedURLHash = GetSHA256Hash(Encoding.UTF8.GetBytes(url));
+                if (!payload["url_hash"].Equals(expectedURLHash))
+                {
+                    throw new RequestValidationException("invalid jwt: claim url_hash is invalid");
+                }
+            }
+
+            bool bodyExist = body != null && body.Length > 0;
+            bool payloadHashExist = payload.ContainsKey("payload_hash");
+            if (!bodyExist && payloadHashExist)
+            {
+                throw new RequestValidationException("invalid jwt: claim payload_hash is set but actual payload is missing");
+            }
+            else if (bodyExist && !payloadHashExist)
+            {
+                throw new RequestValidationException("invalid jwt: claim payload_hash is not set but payload is present");
+            }
+            else if (bodyExist && !payload["payload_hash"].Equals(GetSHA256Hash(body)))
+            {
+                throw new RequestValidationException("invalid jwt: claim payload_hash is invalid");
+            }
+
+            return payload;
+        }
+
+        private static string GetSHA256Hash(byte[] input)
+        {
+            byte[] data = SHA256.Create().ComputeHash(input);
+
+            var sBuilder = new StringBuilder();
+            for (int i = 0; i < data.Length; i++)
+            {
+                sBuilder.Append(data[i].ToString("x2"));
+            }
+            return sBuilder.ToString();
+        }
+    }
+}

--- a/MessageBird/RequestValidator.cs
+++ b/MessageBird/RequestValidator.cs
@@ -9,16 +9,16 @@ using MessageBird.Exceptions;
 namespace MessageBird
 {
     /// <summary>
-    /// Class RequestValidator validates request signature signed by MessageBird services.
+    /// Validates request signature signed by MessageBird services.
     /// </summary>
     ///
     /// <see href="https://developers.messagebird.com/docs/verify-http-requests" />
     public class RequestValidator
     {
+        private const string TokenIssuer = "MessageBird";
         private readonly JwtBuilder _jwtBuilder;
 
         /// <summary>
-        /// This field instructs Validator to not validate url_hash claim.
         /// It is recommended to not skip URL validation to ensure high security.
         /// but the ability to skip URL validation is necessary in some cases, e.g.
         /// your service is behind proxy or when you want to validate it yourself.
@@ -107,14 +107,14 @@ namespace MessageBird
                 throw new RequestValidationException(String.Format("invalid jwt: claim {0} is missing", claim));
             }
 
-            if (!payload["iss"].Equals("MessageBird"))
+            if (!payload["iss"].Equals(TokenIssuer))
             {
                 throw new RequestValidationException("invalid jwt: claim iss has wrong value");
             }
 
             if (!_skipURLValidation)
             {
-                string expectedURLHash = GetSHA256Hash(Encoding.UTF8.GetBytes(url));
+                string expectedURLHash = GetSHA256Hash(Encoding.ASCII.GetBytes(url));
                 if (!payload["url_hash"].Equals(expectedURLHash))
                 {
                     throw new RequestValidationException("invalid jwt: claim url_hash is invalid");
@@ -127,11 +127,11 @@ namespace MessageBird
             {
                 throw new RequestValidationException("invalid jwt: claim payload_hash is set but actual payload is missing");
             }
-            else if (bodyExist && !payloadHashExist)
+            if (bodyExist && !payloadHashExist)
             {
                 throw new RequestValidationException("invalid jwt: claim payload_hash is not set but payload is present");
             }
-            else if (bodyExist && !payload["payload_hash"].Equals(GetSHA256Hash(body)))
+            if (bodyExist && !payload["payload_hash"].Equals(GetSHA256Hash(body)))
             {
                 throw new RequestValidationException("invalid jwt: claim payload_hash is invalid");
             }

--- a/Tests/UnitTests/MessageBirdUnitTests/MessageBirdUnitTests.csproj
+++ b/Tests/UnitTests/MessageBirdUnitTests/MessageBirdUnitTests.csproj
@@ -19,6 +19,9 @@
     <Content Include="Responses\**">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Resources\webhooksignature.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <ItemGroup>
     <None Remove="Responses\VoiceCallFlowList.json" />

--- a/Tests/UnitTests/MessageBirdUnitTests/Resources/RequestSignerTest.cs
+++ b/Tests/UnitTests/MessageBirdUnitTests/Resources/RequestSignerTest.cs
@@ -14,72 +14,72 @@ namespace MessageBirdUnitTests.Resources
             var requestSigner = new RequestSigner(GetBytes("secret"));
             const string expectedSignature = "LISw4Je7n0/MkYDgVSzTJm8dW6BkytKTXMZZk1IElMs=";
             var request = new Request("1544544948", "", GetBytes(""));
-    
+
             Assert.IsTrue(requestSigner.IsMatch(expectedSignature, request));
         }
-    
+
         [TestMethod]
         public void TestIsMatchWithData() {
             var requestSigner = new RequestSigner(GetBytes("secret"));
             const string expectedSignature = "p2e20OtAg39DEmz1ORHpjQ556U4o1ZaH4NWbM9Q8Qjk=";
             var request = new Request("1544544948", "", GetBytes("{\"a key\":\"some value\"}"));
-    
+
             Assert.IsTrue(requestSigner.IsMatch(expectedSignature, request));
         }
-    
+
         [TestMethod]
         public void TestIsMatchWithQueryParams() {
             var requestSigner = new RequestSigner(GetBytes("secret"));
             const string expectedSignature = "Tfn+nRUBsn6lQgf6IpxBMS1j9lm7XsGjt5xh47M3jCk=";
             var request = new Request("1544544948", "abc=foo&def=bar", GetBytes(""));
-    
+
             Assert.IsTrue(requestSigner.IsMatch(expectedSignature, request));
         }
-    
+
         [TestMethod]
         public void TestIsMatchWithShuffledQueryParams() {
             var requestSigner = new RequestSigner(GetBytes("secret"));
             const string expectedSignature = "Tfn+nRUBsn6lQgf6IpxBMS1j9lm7XsGjt5xh47M3jCk=";
             var request = new Request("1544544948", "def=bar&abc=foo", GetBytes(""));
-    
+
             Assert.IsTrue(requestSigner.IsMatch(expectedSignature, request));
         }
-    
+
         [TestMethod]
         public void TestIsMatchWithDataAndQueryParams() {
             var requestSigner = new RequestSigner(GetBytes("other-secret"));
             const string expectedSignature = "orb0adPhRCYND1WCAvPBr+qjm4STGtyvNDIDNBZ4Ir4=";
             var request = new Request("1544544948", "abc=foo&def=bar", GetBytes("{\"a key\":\"some value\"}"));
-    
+
             Assert.IsTrue(requestSigner.IsMatch(expectedSignature, request));
         }
-    
+
         [TestMethod]
         public void TestIsNotMatch() {
             var requestSigner = new RequestSigner(GetBytes("secret"));
             const string expectedSignature = "";
             var request = new Request("1544544948", "abc=foo&def=bar", GetBytes("{\"a key\":\"some value\"}"));
-    
+
             Assert.IsFalse(requestSigner.IsMatch(expectedSignature, request));
         }
-    
+
         [TestMethod]
         public void TestWithRealSignature() {
             /*
              * Here we use real signature from MessageBird webhook call
              */
-    
+
             var requestSigner = new RequestSigner(GetBytes("Wb3N9gKeFf8ZoCzlOb5lJSic7bHLUcSu"));
             const string requestSignature = "5Jha9Yyhwgc1nTsgJ9WyzeHilsuUumydICdf4LuIZE8=";
             const string requestTimestamp = "1547036603";
             const string requestParams = "id=57db52e04e2f4001b555f79813a0f503&mccmnc=20409&ported=0&recipient=31667788880&reference=curl&status=delivered&statusDatetime=2019-01-09T12%3A23%3A23%2B00%3A00";
             var requestBody = new byte[] {};
-    
+
             const string spoiledSignature = "5Jha9Yyhwgc1nTsgJ9WyzeHilsuUumydICdf4LUIZE8=";
             const string spoiledTimestamp = "1547036605";
             const string spoiledParams = "id=57db52e04e2f4001b555f79813a0f503&mccmnc=20409&ported=0&recipient=31667788880&reference=curvy&status=delivered&statusDatetime=2019-01-09T12%3A23%3A23%2B00%3A00";
             var spoiledBody = GetBytes("get shit spoiled");
-    
+
             Assert.IsTrue(
                 requestSigner.IsMatch(requestSignature, new Request(requestTimestamp, requestParams, requestBody)),
                 "Definitely valid signature is threaten as invalid"
@@ -101,7 +101,7 @@ namespace MessageBirdUnitTests.Resources
                 "Signature is still valid with replaced body"
             );
         }
-            
+
         /**
          * Helper to get the bytes the provided UTF-8 encoded string represents.
          */

--- a/Tests/UnitTests/MessageBirdUnitTests/Resources/RequestValidatorTest.cs
+++ b/Tests/UnitTests/MessageBirdUnitTests/Resources/RequestValidatorTest.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Text;
+using JWT;
+using MessageBird;
+using MessageBird.Exceptions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+
+namespace MessageBirdUnitTests.Resources
+{
+    [TestClass]
+    public class RequestValidatorTest
+    {
+        private static Dictionary<string, string> errorMap = new Dictionary<string, string>
+        {
+            { "invalid jwt: claim nbf is in the future", "Token is not yet valid." },
+            { "invalid jwt: claim exp is in the past", "Token has expired." },
+            { "invalid jwt: signature is invalid", "Invalid signature" },
+            { "invalid jwt: signing method none is invalid", "Specified argument was out of the range of valid values" }
+        };
+
+        [DynamicData(nameof(TestData), DynamicDataDisplayName = nameof(TestCaseDisplayName))]
+        [TestMethod()]
+        public void TestValidateSignature(TestCase tc)
+        {
+            string signingKey = tc.secret != null && tc.secret.Length > 0 ? tc.secret : "";
+            RequestValidator requestValidator = new RequestValidator(signingKey, new StaticDateTimeProvider(tc.timestamp));
+
+            byte[] body = tc.payload != null && tc.payload.Length > 0 ? Encoding.UTF8.GetBytes(tc.payload) : null;
+
+            Func<IDictionary<string, string>> runValidateSignature = () => requestValidator.ValidateSignature(tc.token, tc.url, body);
+
+            if (tc.valid)
+            {
+                var decoded = runValidateSignature();
+                Assert.IsNotNull(decoded);
+            }
+            else
+            {
+                string expectedErrorMessage = errorMap.ContainsKey(tc.reason) ? errorMap[tc.reason] : tc.reason;
+
+                var err = Assert.ThrowsException<RequestValidationException>(runValidateSignature);
+                StringAssert.Contains(err.Message, expectedErrorMessage);
+            }
+        }
+
+        public static string TestCaseDisplayName(MethodInfo methodInfo, object[] testCases) =>
+            $"{methodInfo.Name}_{((TestCase)testCases[0]).name}";
+
+        public static IEnumerable<object[]> TestData
+        {
+            get
+            {
+                var json = File.ReadAllText(Path.Combine(Environment.CurrentDirectory, @"Resources", "webhooksignature.json"));
+                List<TestCase> tcs = JsonConvert.DeserializeObject<List<TestCase>>(json);
+
+                foreach (var tc in tcs)
+                {
+                    yield return new[] { tc };
+                }
+            }
+        }
+
+        public sealed class StaticDateTimeProvider : IDateTimeProvider
+        {
+            private readonly DateTimeOffset _now;
+
+            public StaticDateTimeProvider(string timestamp)
+            {
+                _now = DateTimeOffset.Parse(timestamp);
+            }
+
+            public DateTimeOffset GetNow()
+            {
+                return _now;
+            }
+        }
+        public class TestCase
+        {
+            public string name { get; set; }
+            public string secret { get; set; }
+            public string url { get; set; }
+            public string payload { get; set; }
+            public string timestamp { get; set; }
+            public string token { get; set; }
+            public bool valid { get; set; }
+            public string reason { get; set; }
+        }
+    }
+}

--- a/Tests/UnitTests/MessageBirdUnitTests/Resources/webhooksignature.json
+++ b/Tests/UnitTests/MessageBirdUnitTests/Resources/webhooksignature.json
@@ -1,0 +1,443 @@
+
+[
+    {
+        "name": "Valid JWT with no URL parameters or payload - DELETE",
+        "method": "DELETE",
+        "secret": "36efdd1aace2e26cd490f0d951138253bef2f7c6d34d18981da781555cc4cebb",
+        "url": "https://example.com/",
+        "timestamp": "2021-07-05T12:00:00+02:00",
+        "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJNZXNzYWdlQmlyZCIsIm5iZiI6MTYyNTQ3OTIwMCwiZXhwIjoxNjI1NDc5MjYwLCJqdGkiOiI1OWEyNDRkYy1lOWFkLTRlMjMtOTc3OC0zNzFmYWEyMzhmNzIiLCJ1cmxfaGFzaCI6IjBmMTE1ZGIwNjJiN2MwZGQwMzBiMTY4NzhjOTlkZWE1YzM1NGI0OWRjMzdiMzhlYjg4NDYxNzljNzc4M2U5ZDcifQ.6Fp0rVOsRr1fj9S2GidXAfkmPVofKr8_RTffC6G6r2E",
+        "valid": true
+    },
+    {
+        "name": "Valid JWT with no URL parameters or payload - GET",
+        "method": "GET",
+        "secret": "36efdd1aace2e26cd490f0d951138253bef2f7c6d34d18981da781555cc4cebb",
+        "url": "https://example.com/",
+        "timestamp": "2021-07-05T12:00:00+02:00",
+        "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJNZXNzYWdlQmlyZCIsIm5iZiI6MTYyNTQ3OTIwMCwiZXhwIjoxNjI1NDc5MjYwLCJqdGkiOiI1OWEyNDRkYy1lOWFkLTRlMjMtOTc3OC0zNzFmYWEyMzhmNzIiLCJ1cmxfaGFzaCI6IjBmMTE1ZGIwNjJiN2MwZGQwMzBiMTY4NzhjOTlkZWE1YzM1NGI0OWRjMzdiMzhlYjg4NDYxNzljNzc4M2U5ZDcifQ.6Fp0rVOsRr1fj9S2GidXAfkmPVofKr8_RTffC6G6r2E",
+        "valid": true
+    },
+    {
+        "name": "Valid JWT with no URL parameters or payload - PATCH",
+        "method": "PATCH",
+        "secret": "36efdd1aace2e26cd490f0d951138253bef2f7c6d34d18981da781555cc4cebb",
+        "url": "https://example.com/",
+        "timestamp": "2021-07-05T12:00:00+02:00",
+        "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJNZXNzYWdlQmlyZCIsIm5iZiI6MTYyNTQ3OTIwMCwiZXhwIjoxNjI1NDc5MjYwLCJqdGkiOiI1OWEyNDRkYy1lOWFkLTRlMjMtOTc3OC0zNzFmYWEyMzhmNzIiLCJ1cmxfaGFzaCI6IjBmMTE1ZGIwNjJiN2MwZGQwMzBiMTY4NzhjOTlkZWE1YzM1NGI0OWRjMzdiMzhlYjg4NDYxNzljNzc4M2U5ZDcifQ.6Fp0rVOsRr1fj9S2GidXAfkmPVofKr8_RTffC6G6r2E",
+        "valid": true
+    },
+    {
+        "name": "Valid JWT with no URL parameters or payload - POST",
+        "method": "POST",
+        "secret": "36efdd1aace2e26cd490f0d951138253bef2f7c6d34d18981da781555cc4cebb",
+        "url": "https://example.com/",
+        "timestamp": "2021-07-05T12:00:00+02:00",
+        "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJNZXNzYWdlQmlyZCIsIm5iZiI6MTYyNTQ3OTIwMCwiZXhwIjoxNjI1NDc5MjYwLCJqdGkiOiI1OWEyNDRkYy1lOWFkLTRlMjMtOTc3OC0zNzFmYWEyMzhmNzIiLCJ1cmxfaGFzaCI6IjBmMTE1ZGIwNjJiN2MwZGQwMzBiMTY4NzhjOTlkZWE1YzM1NGI0OWRjMzdiMzhlYjg4NDYxNzljNzc4M2U5ZDcifQ.6Fp0rVOsRr1fj9S2GidXAfkmPVofKr8_RTffC6G6r2E",
+        "valid": true
+    },
+    {
+        "name": "Valid JWT with no URL parameters or payload - PUT",
+        "method": "PUT",
+        "secret": "36efdd1aace2e26cd490f0d951138253bef2f7c6d34d18981da781555cc4cebb",
+        "url": "https://example.com/",
+        "timestamp": "2021-07-05T12:00:00+02:00",
+        "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJNZXNzYWdlQmlyZCIsIm5iZiI6MTYyNTQ3OTIwMCwiZXhwIjoxNjI1NDc5MjYwLCJqdGkiOiI1OWEyNDRkYy1lOWFkLTRlMjMtOTc3OC0zNzFmYWEyMzhmNzIiLCJ1cmxfaGFzaCI6IjBmMTE1ZGIwNjJiN2MwZGQwMzBiMTY4NzhjOTlkZWE1YzM1NGI0OWRjMzdiMzhlYjg4NDYxNzljNzc4M2U5ZDcifQ.6Fp0rVOsRr1fj9S2GidXAfkmPVofKr8_RTffC6G6r2E",
+        "valid": true
+    },
+    {
+        "name": "Valid JWT with URL parameters and no payload - DELETE",
+        "method": "DELETE",
+        "secret": "36efdd1aace2e26cd490f0d951138253bef2f7c6d34d18981da781555cc4cebb",
+        "url": "https://example.com/path?bar=1\u0026foo=2",
+        "timestamp": "2021-07-05T12:00:00+02:00",
+        "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJNZXNzYWdlQmlyZCIsIm5iZiI6MTYyNTQ3OTIwMCwiZXhwIjoxNjI1NDc5MjYwLCJqdGkiOiJjOTQ2YWY3Ny1lMTgyLTRlYWEtYjJmZi0xYTU0NWI1ZTk5MWEiLCJ1cmxfaGFzaCI6IjQxZjA1ZjBkZGQwYTIyYWIyMDlhYzQ2ZjQ3YzQ1NzJkOWNlZmEyNTdlZDc0YjI0MDA0YmFlNzUzZWNlNmMyNjAifQ.huo2ou6JDoDc7sV25d75UMWeYhBeavQlLsqIibSZuac",
+        "valid": true
+    },
+    {
+        "name": "Valid JWT with URL parameters and no payload - GET",
+        "method": "GET",
+        "secret": "36efdd1aace2e26cd490f0d951138253bef2f7c6d34d18981da781555cc4cebb",
+        "url": "https://example.com/path?bar=1\u0026foo=2",
+        "timestamp": "2021-07-05T12:00:00+02:00",
+        "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJNZXNzYWdlQmlyZCIsIm5iZiI6MTYyNTQ3OTIwMCwiZXhwIjoxNjI1NDc5MjYwLCJqdGkiOiJjOTQ2YWY3Ny1lMTgyLTRlYWEtYjJmZi0xYTU0NWI1ZTk5MWEiLCJ1cmxfaGFzaCI6IjQxZjA1ZjBkZGQwYTIyYWIyMDlhYzQ2ZjQ3YzQ1NzJkOWNlZmEyNTdlZDc0YjI0MDA0YmFlNzUzZWNlNmMyNjAifQ.huo2ou6JDoDc7sV25d75UMWeYhBeavQlLsqIibSZuac",
+        "valid": true
+    },
+    {
+        "name": "Valid JWT with URL parameters and no payload - PATCH",
+        "method": "PATCH",
+        "secret": "36efdd1aace2e26cd490f0d951138253bef2f7c6d34d18981da781555cc4cebb",
+        "url": "https://example.com/path?bar=1\u0026foo=2",
+        "timestamp": "2021-07-05T12:00:00+02:00",
+        "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJNZXNzYWdlQmlyZCIsIm5iZiI6MTYyNTQ3OTIwMCwiZXhwIjoxNjI1NDc5MjYwLCJqdGkiOiJjOTQ2YWY3Ny1lMTgyLTRlYWEtYjJmZi0xYTU0NWI1ZTk5MWEiLCJ1cmxfaGFzaCI6IjQxZjA1ZjBkZGQwYTIyYWIyMDlhYzQ2ZjQ3YzQ1NzJkOWNlZmEyNTdlZDc0YjI0MDA0YmFlNzUzZWNlNmMyNjAifQ.huo2ou6JDoDc7sV25d75UMWeYhBeavQlLsqIibSZuac",
+        "valid": true
+    },
+    {
+        "name": "Valid JWT with URL parameters and no payload - POST",
+        "method": "POST",
+        "secret": "36efdd1aace2e26cd490f0d951138253bef2f7c6d34d18981da781555cc4cebb",
+        "url": "https://example.com/path?bar=1\u0026foo=2",
+        "timestamp": "2021-07-05T12:00:00+02:00",
+        "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJNZXNzYWdlQmlyZCIsIm5iZiI6MTYyNTQ3OTIwMCwiZXhwIjoxNjI1NDc5MjYwLCJqdGkiOiJjOTQ2YWY3Ny1lMTgyLTRlYWEtYjJmZi0xYTU0NWI1ZTk5MWEiLCJ1cmxfaGFzaCI6IjQxZjA1ZjBkZGQwYTIyYWIyMDlhYzQ2ZjQ3YzQ1NzJkOWNlZmEyNTdlZDc0YjI0MDA0YmFlNzUzZWNlNmMyNjAifQ.huo2ou6JDoDc7sV25d75UMWeYhBeavQlLsqIibSZuac",
+        "valid": true
+    },
+    {
+        "name": "Valid JWT with URL parameters and no payload - PUT",
+        "method": "PUT",
+        "secret": "36efdd1aace2e26cd490f0d951138253bef2f7c6d34d18981da781555cc4cebb",
+        "url": "https://example.com/path?bar=1\u0026foo=2",
+        "timestamp": "2021-07-05T12:00:00+02:00",
+        "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJNZXNzYWdlQmlyZCIsIm5iZiI6MTYyNTQ3OTIwMCwiZXhwIjoxNjI1NDc5MjYwLCJqdGkiOiJjOTQ2YWY3Ny1lMTgyLTRlYWEtYjJmZi0xYTU0NWI1ZTk5MWEiLCJ1cmxfaGFzaCI6IjQxZjA1ZjBkZGQwYTIyYWIyMDlhYzQ2ZjQ3YzQ1NzJkOWNlZmEyNTdlZDc0YjI0MDA0YmFlNzUzZWNlNmMyNjAifQ.huo2ou6JDoDc7sV25d75UMWeYhBeavQlLsqIibSZuac",
+        "valid": true
+    },
+    {
+        "name": "Valid JWT with URL parameters and payload - DELETE",
+        "method": "DELETE",
+        "secret": "36efdd1aace2e26cd490f0d951138253bef2f7c6d34d18981da781555cc4cebb",
+        "url": "https://example.com/path?bar=1\u0026foo=2",
+        "payload": "Hello, World!",
+        "timestamp": "2021-07-05T12:00:00+02:00",
+        "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJNZXNzYWdlQmlyZCIsIm5iZiI6MTYyNTQ3OTIwMCwiZXhwIjoxNjI1NDc5MjYwLCJqdGkiOiI5M2U1NTAwNi1hMGU4LTQ1MjYtYTE5MC1mYTVmZjAwZWExMTYiLCJ1cmxfaGFzaCI6IjQxZjA1ZjBkZGQwYTIyYWIyMDlhYzQ2ZjQ3YzQ1NzJkOWNlZmEyNTdlZDc0YjI0MDA0YmFlNzUzZWNlNmMyNjAiLCJwYXlsb2FkX2hhc2giOiJkZmZkNjAyMWJiMmJkNWIwYWY2NzYyOTA4MDllYzNhNTMxOTFkZDgxYzdmNzBhNGIyODY4OGEzNjIxODI5ODZmIn0._H--TOuYFLpeEH39-rg5E3IHVkjHozBcaKVWPRC5m9I",
+        "valid": true
+    },
+    {
+        "name": "Valid JWT with URL parameters and payload - GET",
+        "method": "GET",
+        "secret": "36efdd1aace2e26cd490f0d951138253bef2f7c6d34d18981da781555cc4cebb",
+        "url": "https://example.com/path?bar=1\u0026foo=2",
+        "payload": "Hello, World!",
+        "timestamp": "2021-07-05T12:00:00+02:00",
+        "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJNZXNzYWdlQmlyZCIsIm5iZiI6MTYyNTQ3OTIwMCwiZXhwIjoxNjI1NDc5MjYwLCJqdGkiOiI5M2U1NTAwNi1hMGU4LTQ1MjYtYTE5MC1mYTVmZjAwZWExMTYiLCJ1cmxfaGFzaCI6IjQxZjA1ZjBkZGQwYTIyYWIyMDlhYzQ2ZjQ3YzQ1NzJkOWNlZmEyNTdlZDc0YjI0MDA0YmFlNzUzZWNlNmMyNjAiLCJwYXlsb2FkX2hhc2giOiJkZmZkNjAyMWJiMmJkNWIwYWY2NzYyOTA4MDllYzNhNTMxOTFkZDgxYzdmNzBhNGIyODY4OGEzNjIxODI5ODZmIn0._H--TOuYFLpeEH39-rg5E3IHVkjHozBcaKVWPRC5m9I",
+        "valid": true
+    },
+    {
+        "name": "Valid JWT with URL parameters and payload - PATCH",
+        "method": "PATCH",
+        "secret": "36efdd1aace2e26cd490f0d951138253bef2f7c6d34d18981da781555cc4cebb",
+        "url": "https://example.com/path?bar=1\u0026foo=2",
+        "payload": "Hello, World!",
+        "timestamp": "2021-07-05T12:00:00+02:00",
+        "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJNZXNzYWdlQmlyZCIsIm5iZiI6MTYyNTQ3OTIwMCwiZXhwIjoxNjI1NDc5MjYwLCJqdGkiOiI5M2U1NTAwNi1hMGU4LTQ1MjYtYTE5MC1mYTVmZjAwZWExMTYiLCJ1cmxfaGFzaCI6IjQxZjA1ZjBkZGQwYTIyYWIyMDlhYzQ2ZjQ3YzQ1NzJkOWNlZmEyNTdlZDc0YjI0MDA0YmFlNzUzZWNlNmMyNjAiLCJwYXlsb2FkX2hhc2giOiJkZmZkNjAyMWJiMmJkNWIwYWY2NzYyOTA4MDllYzNhNTMxOTFkZDgxYzdmNzBhNGIyODY4OGEzNjIxODI5ODZmIn0._H--TOuYFLpeEH39-rg5E3IHVkjHozBcaKVWPRC5m9I",
+        "valid": true
+    },
+    {
+        "name": "Valid JWT with URL parameters and payload - POST",
+        "method": "POST",
+        "secret": "36efdd1aace2e26cd490f0d951138253bef2f7c6d34d18981da781555cc4cebb",
+        "url": "https://example.com/path?bar=1\u0026foo=2",
+        "payload": "Hello, World!",
+        "timestamp": "2021-07-05T12:00:00+02:00",
+        "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJNZXNzYWdlQmlyZCIsIm5iZiI6MTYyNTQ3OTIwMCwiZXhwIjoxNjI1NDc5MjYwLCJqdGkiOiI5M2U1NTAwNi1hMGU4LTQ1MjYtYTE5MC1mYTVmZjAwZWExMTYiLCJ1cmxfaGFzaCI6IjQxZjA1ZjBkZGQwYTIyYWIyMDlhYzQ2ZjQ3YzQ1NzJkOWNlZmEyNTdlZDc0YjI0MDA0YmFlNzUzZWNlNmMyNjAiLCJwYXlsb2FkX2hhc2giOiJkZmZkNjAyMWJiMmJkNWIwYWY2NzYyOTA4MDllYzNhNTMxOTFkZDgxYzdmNzBhNGIyODY4OGEzNjIxODI5ODZmIn0._H--TOuYFLpeEH39-rg5E3IHVkjHozBcaKVWPRC5m9I",
+        "valid": true
+    },
+    {
+        "name": "Valid JWT with URL parameters and payload - PUT",
+        "method": "PUT",
+        "secret": "36efdd1aace2e26cd490f0d951138253bef2f7c6d34d18981da781555cc4cebb",
+        "url": "https://example.com/path?bar=1\u0026foo=2",
+        "payload": "Hello, World!",
+        "timestamp": "2021-07-05T12:00:00+02:00",
+        "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJNZXNzYWdlQmlyZCIsIm5iZiI6MTYyNTQ3OTIwMCwiZXhwIjoxNjI1NDc5MjYwLCJqdGkiOiI5M2U1NTAwNi1hMGU4LTQ1MjYtYTE5MC1mYTVmZjAwZWExMTYiLCJ1cmxfaGFzaCI6IjQxZjA1ZjBkZGQwYTIyYWIyMDlhYzQ2ZjQ3YzQ1NzJkOWNlZmEyNTdlZDc0YjI0MDA0YmFlNzUzZWNlNmMyNjAiLCJwYXlsb2FkX2hhc2giOiJkZmZkNjAyMWJiMmJkNWIwYWY2NzYyOTA4MDllYzNhNTMxOTFkZDgxYzdmNzBhNGIyODY4OGEzNjIxODI5ODZmIn0._H--TOuYFLpeEH39-rg5E3IHVkjHozBcaKVWPRC5m9I",
+        "valid": true
+    },
+    {
+        "name": "Token received before it was issued - GET",
+        "method": "GET",
+        "secret": "36efdd1aace2e26cd490f0d951138253bef2f7c6d34d18981da781555cc4cebb",
+        "url": "https://example.com/",
+        "timestamp": "2021-07-05T12:00:00+02:00",
+        "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJNZXNzYWdlQmlyZCIsIm5iZiI6MTYyNTQ4MjgwMCwiZXhwIjoxNjI1NDgyODYwLCJqdGkiOiJmOWY4YzM4Mi0yNDQ5LTQzMTEtYjcyYi0xZGY3MTY4NzkzMWUiLCJ1cmxfaGFzaCI6IjBmMTE1ZGIwNjJiN2MwZGQwMzBiMTY4NzhjOTlkZWE1YzM1NGI0OWRjMzdiMzhlYjg4NDYxNzljNzc4M2U5ZDcifQ.ZELgDFNGhjZH9CffQKcq3sytBe2I0KciLxpBhcfstHQ",
+        "valid": false,
+        "reason": "invalid jwt: claim nbf is in the future"
+    },
+    {
+        "name": "Token received after it was expired - GET",
+        "method": "GET",
+        "secret": "36efdd1aace2e26cd490f0d951138253bef2f7c6d34d18981da781555cc4cebb",
+        "url": "https://example.com/",
+        "timestamp": "2021-07-05T12:00:00+02:00",
+        "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJNZXNzYWdlQmlyZCIsIm5iZiI6MTYyNTQ3NTYwMCwiZXhwIjoxNjI1NDc1NjYwLCJqdGkiOiI1ZjAyZjUyMi02MDMwLTQ2YzgtYjVhMy0wMTI0NjQ3OGQ4YmMiLCJ1cmxfaGFzaCI6IjBmMTE1ZGIwNjJiN2MwZGQwMzBiMTY4NzhjOTlkZWE1YzM1NGI0OWRjMzdiMzhlYjg4NDYxNzljNzc4M2U5ZDcifQ.45MSST3B_2PsjNUeiuW54_vUQgVw4rBXrdWrOUEz3lM",
+        "valid": false,
+        "reason": "invalid jwt: claim exp is in the past"
+    },
+    {
+        "name": "Token received on different URL (parameters were sorted out of order) - GET",
+        "method": "GET",
+        "secret": "36efdd1aace2e26cd490f0d951138253bef2f7c6d34d18981da781555cc4cebb",
+        "url": "https://example.com/path?foo=1\u0026bar=2",
+        "timestamp": "2021-07-05T12:00:00+02:00",
+        "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJNZXNzYWdlQmlyZCIsIm5iZiI6MTYyNTQ3OTIwMCwiZXhwIjoxNjI1NDc5MjYwLCJqdGkiOiJhNzVjOTA5Ni1lODIzLTQ0MmItODVmMi03ZDNjOWQ5YjcyNmIiLCJ1cmxfaGFzaCI6IjZhMDIyZDgzNGMxODMzMGJhYWQ4YTJiZDYxMzUxNzNlZDIxNjEwYTQ1NDUxNmJlMGRmM2YxY2MwMTUxNjEwZWEifQ.z6Sw1XQIM0wuEQGBhXBdawDIIrtMg2XnmA_bpDq53pE",
+        "valid": false,
+        "reason": "invalid jwt: claim url_hash is invalid"
+    },
+    {
+        "name": "Payload does not match - DELETE",
+        "method": "DELETE",
+        "secret": "36efdd1aace2e26cd490f0d951138253bef2f7c6d34d18981da781555cc4cebb",
+        "url": "https://example.com/",
+        "payload": "Hello, World!",
+        "timestamp": "2021-07-05T12:00:00+02:00",
+        "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJNZXNzYWdlQmlyZCIsIm5iZiI6MTYyNTQ3OTIwMCwiZXhwIjoxNjI1NDc5MjYwLCJqdGkiOiIxNDUwMTUzMi05NmYyLTQ2ODQtOTgzMi02OGYwOTUxYWUzNDIiLCJ1cmxfaGFzaCI6IjBmMTE1ZGIwNjJiN2MwZGQwMzBiMTY4NzhjOTlkZWE1YzM1NGI0OWRjMzdiMzhlYjg4NDYxNzljNzc4M2U5ZDciLCJwYXlsb2FkX2hhc2giOiJmYjYyZjAyYWNkYTdkNzQxNzdhNzAxYTFjZTAwNmU2YmFjZDkwYzdkNGQ3YWI0ODE2OTJjMWRhNDdjODEwNzZiIn0.m79RCwO6dGa9pvzsQypkVuXQ6eM0CkRl6_U7MfWg6TM",
+        "valid": false,
+        "reason": "invalid jwt: claim payload_hash is invalid"
+    },
+    {
+        "name": "Payload does not match - GET",
+        "method": "GET",
+        "secret": "36efdd1aace2e26cd490f0d951138253bef2f7c6d34d18981da781555cc4cebb",
+        "url": "https://example.com/",
+        "payload": "Hello, World!",
+        "timestamp": "2021-07-05T12:00:00+02:00",
+        "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJNZXNzYWdlQmlyZCIsIm5iZiI6MTYyNTQ3OTIwMCwiZXhwIjoxNjI1NDc5MjYwLCJqdGkiOiIxNDUwMTUzMi05NmYyLTQ2ODQtOTgzMi02OGYwOTUxYWUzNDIiLCJ1cmxfaGFzaCI6IjBmMTE1ZGIwNjJiN2MwZGQwMzBiMTY4NzhjOTlkZWE1YzM1NGI0OWRjMzdiMzhlYjg4NDYxNzljNzc4M2U5ZDciLCJwYXlsb2FkX2hhc2giOiJmYjYyZjAyYWNkYTdkNzQxNzdhNzAxYTFjZTAwNmU2YmFjZDkwYzdkNGQ3YWI0ODE2OTJjMWRhNDdjODEwNzZiIn0.m79RCwO6dGa9pvzsQypkVuXQ6eM0CkRl6_U7MfWg6TM",
+        "valid": false,
+        "reason": "invalid jwt: claim payload_hash is invalid"
+    },
+    {
+        "name": "Payload does not match - PATCH",
+        "method": "PATCH",
+        "secret": "36efdd1aace2e26cd490f0d951138253bef2f7c6d34d18981da781555cc4cebb",
+        "url": "https://example.com/",
+        "payload": "Hello, World!",
+        "timestamp": "2021-07-05T12:00:00+02:00",
+        "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJNZXNzYWdlQmlyZCIsIm5iZiI6MTYyNTQ3OTIwMCwiZXhwIjoxNjI1NDc5MjYwLCJqdGkiOiIxNDUwMTUzMi05NmYyLTQ2ODQtOTgzMi02OGYwOTUxYWUzNDIiLCJ1cmxfaGFzaCI6IjBmMTE1ZGIwNjJiN2MwZGQwMzBiMTY4NzhjOTlkZWE1YzM1NGI0OWRjMzdiMzhlYjg4NDYxNzljNzc4M2U5ZDciLCJwYXlsb2FkX2hhc2giOiJmYjYyZjAyYWNkYTdkNzQxNzdhNzAxYTFjZTAwNmU2YmFjZDkwYzdkNGQ3YWI0ODE2OTJjMWRhNDdjODEwNzZiIn0.m79RCwO6dGa9pvzsQypkVuXQ6eM0CkRl6_U7MfWg6TM",
+        "valid": false,
+        "reason": "invalid jwt: claim payload_hash is invalid"
+    },
+    {
+        "name": "Payload does not match - POST",
+        "method": "POST",
+        "secret": "36efdd1aace2e26cd490f0d951138253bef2f7c6d34d18981da781555cc4cebb",
+        "url": "https://example.com/",
+        "payload": "Hello, World!",
+        "timestamp": "2021-07-05T12:00:00+02:00",
+        "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJNZXNzYWdlQmlyZCIsIm5iZiI6MTYyNTQ3OTIwMCwiZXhwIjoxNjI1NDc5MjYwLCJqdGkiOiIxNDUwMTUzMi05NmYyLTQ2ODQtOTgzMi02OGYwOTUxYWUzNDIiLCJ1cmxfaGFzaCI6IjBmMTE1ZGIwNjJiN2MwZGQwMzBiMTY4NzhjOTlkZWE1YzM1NGI0OWRjMzdiMzhlYjg4NDYxNzljNzc4M2U5ZDciLCJwYXlsb2FkX2hhc2giOiJmYjYyZjAyYWNkYTdkNzQxNzdhNzAxYTFjZTAwNmU2YmFjZDkwYzdkNGQ3YWI0ODE2OTJjMWRhNDdjODEwNzZiIn0.m79RCwO6dGa9pvzsQypkVuXQ6eM0CkRl6_U7MfWg6TM",
+        "valid": false,
+        "reason": "invalid jwt: claim payload_hash is invalid"
+    },
+    {
+        "name": "Payload does not match - PUT",
+        "method": "PUT",
+        "secret": "36efdd1aace2e26cd490f0d951138253bef2f7c6d34d18981da781555cc4cebb",
+        "url": "https://example.com/",
+        "payload": "Hello, World!",
+        "timestamp": "2021-07-05T12:00:00+02:00",
+        "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJNZXNzYWdlQmlyZCIsIm5iZiI6MTYyNTQ3OTIwMCwiZXhwIjoxNjI1NDc5MjYwLCJqdGkiOiIxNDUwMTUzMi05NmYyLTQ2ODQtOTgzMi02OGYwOTUxYWUzNDIiLCJ1cmxfaGFzaCI6IjBmMTE1ZGIwNjJiN2MwZGQwMzBiMTY4NzhjOTlkZWE1YzM1NGI0OWRjMzdiMzhlYjg4NDYxNzljNzc4M2U5ZDciLCJwYXlsb2FkX2hhc2giOiJmYjYyZjAyYWNkYTdkNzQxNzdhNzAxYTFjZTAwNmU2YmFjZDkwYzdkNGQ3YWI0ODE2OTJjMWRhNDdjODEwNzZiIn0.m79RCwO6dGa9pvzsQypkVuXQ6eM0CkRl6_U7MfWg6TM",
+        "valid": false,
+        "reason": "invalid jwt: claim payload_hash is invalid"
+    },
+    {
+        "name": "Different secret - GET",
+        "method": "GET",
+        "secret": "36efdd1aace2e26cd490f0d951138253bef2f7c6d34d18981da781555cc4cebb",
+        "url": "https://example.com/",
+        "timestamp": "2021-07-05T12:00:00+02:00",
+        "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJNZXNzYWdlQmlyZCIsIm5iZiI6MTYyNTQ3OTIwMCwiZXhwIjoxNjI1NDc5MjYwLCJqdGkiOiIyNDNjMjdhZS0yZjAyLTQ2YTAtODg1Mi1jNjZmMzdlYTlmNDYiLCJ1cmxfaGFzaCI6IjBmMTE1ZGIwNjJiN2MwZGQwMzBiMTY4NzhjOTlkZWE1YzM1NGI0OWRjMzdiMzhlYjg4NDYxNzljNzc4M2U5ZDcifQ.JgSeYyOtlEKAXk8bz30iJI4tXgf4lxknoiezawuVhb4",
+        "valid": false,
+        "reason": "invalid jwt: signature is invalid"
+    },
+    {
+        "name": "payload was removed in transit - DELETE",
+        "method": "DELETE",
+        "secret": "36efdd1aace2e26cd490f0d951138253bef2f7c6d34d18981da781555cc4cebb",
+        "url": "https://example.com/",
+        "payload": "",
+        "timestamp": "2021-07-05T12:00:00+02:00",
+        "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJNZXNzYWdlQmlyZCIsIm5iZiI6MTYyNTQ3OTIwMCwiZXhwIjoxNjI1NDc5MjYwLCJqdGkiOiIxNDUwMTUzMi05NmYyLTQ2ODQtOTgzMi02OGYwOTUxYWUzNDIiLCJ1cmxfaGFzaCI6IjBmMTE1ZGIwNjJiN2MwZGQwMzBiMTY4NzhjOTlkZWE1YzM1NGI0OWRjMzdiMzhlYjg4NDYxNzljNzc4M2U5ZDciLCJwYXlsb2FkX2hhc2giOiJkZmZkNjAyMWJiMmJkNWIwYWY2NzYyOTA4MDllYzNhNTMxOTFkZDgxYzdmNzBhNGIyODY4OGEzNjIxODI5ODZmIn0.bHfsjj3tljfzTufoG3EU3p_yFrQh9CufyzRSaRMd4ss",
+        "valid": false,
+        "reason": "invalid jwt: claim payload_hash is set but actual payload is missing"
+    },
+    {
+        "name": "payload was removed in transit - GET",
+        "method": "GET",
+        "secret": "36efdd1aace2e26cd490f0d951138253bef2f7c6d34d18981da781555cc4cebb",
+        "url": "https://example.com/",
+        "payload": "",
+        "timestamp": "2021-07-05T12:00:00+02:00",
+        "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJNZXNzYWdlQmlyZCIsIm5iZiI6MTYyNTQ3OTIwMCwiZXhwIjoxNjI1NDc5MjYwLCJqdGkiOiIxNDUwMTUzMi05NmYyLTQ2ODQtOTgzMi02OGYwOTUxYWUzNDIiLCJ1cmxfaGFzaCI6IjBmMTE1ZGIwNjJiN2MwZGQwMzBiMTY4NzhjOTlkZWE1YzM1NGI0OWRjMzdiMzhlYjg4NDYxNzljNzc4M2U5ZDciLCJwYXlsb2FkX2hhc2giOiJkZmZkNjAyMWJiMmJkNWIwYWY2NzYyOTA4MDllYzNhNTMxOTFkZDgxYzdmNzBhNGIyODY4OGEzNjIxODI5ODZmIn0.bHfsjj3tljfzTufoG3EU3p_yFrQh9CufyzRSaRMd4ss",
+        "valid": false,
+        "reason": "invalid jwt: claim payload_hash is set but actual payload is missing"
+    },
+    {
+        "name": "payload was removed in transit - PATCH",
+        "method": "PATCH",
+        "secret": "36efdd1aace2e26cd490f0d951138253bef2f7c6d34d18981da781555cc4cebb",
+        "url": "https://example.com/",
+        "payload": "",
+        "timestamp": "2021-07-05T12:00:00+02:00",
+        "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJNZXNzYWdlQmlyZCIsIm5iZiI6MTYyNTQ3OTIwMCwiZXhwIjoxNjI1NDc5MjYwLCJqdGkiOiIxNDUwMTUzMi05NmYyLTQ2ODQtOTgzMi02OGYwOTUxYWUzNDIiLCJ1cmxfaGFzaCI6IjBmMTE1ZGIwNjJiN2MwZGQwMzBiMTY4NzhjOTlkZWE1YzM1NGI0OWRjMzdiMzhlYjg4NDYxNzljNzc4M2U5ZDciLCJwYXlsb2FkX2hhc2giOiJkZmZkNjAyMWJiMmJkNWIwYWY2NzYyOTA4MDllYzNhNTMxOTFkZDgxYzdmNzBhNGIyODY4OGEzNjIxODI5ODZmIn0.bHfsjj3tljfzTufoG3EU3p_yFrQh9CufyzRSaRMd4ss",
+        "valid": false,
+        "reason": "invalid jwt: claim payload_hash is set but actual payload is missing"
+    },
+    {
+        "name": "payload was removed in transit - POST",
+        "method": "POST",
+        "secret": "36efdd1aace2e26cd490f0d951138253bef2f7c6d34d18981da781555cc4cebb",
+        "url": "https://example.com/",
+        "payload": "",
+        "timestamp": "2021-07-05T12:00:00+02:00",
+        "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJNZXNzYWdlQmlyZCIsIm5iZiI6MTYyNTQ3OTIwMCwiZXhwIjoxNjI1NDc5MjYwLCJqdGkiOiIxNDUwMTUzMi05NmYyLTQ2ODQtOTgzMi02OGYwOTUxYWUzNDIiLCJ1cmxfaGFzaCI6IjBmMTE1ZGIwNjJiN2MwZGQwMzBiMTY4NzhjOTlkZWE1YzM1NGI0OWRjMzdiMzhlYjg4NDYxNzljNzc4M2U5ZDciLCJwYXlsb2FkX2hhc2giOiJkZmZkNjAyMWJiMmJkNWIwYWY2NzYyOTA4MDllYzNhNTMxOTFkZDgxYzdmNzBhNGIyODY4OGEzNjIxODI5ODZmIn0.bHfsjj3tljfzTufoG3EU3p_yFrQh9CufyzRSaRMd4ss",
+        "valid": false,
+        "reason": "invalid jwt: claim payload_hash is set but actual payload is missing"
+    },
+    {
+        "name": "payload was removed in transit - PUT",
+        "method": "PUT",
+        "secret": "36efdd1aace2e26cd490f0d951138253bef2f7c6d34d18981da781555cc4cebb",
+        "url": "https://example.com/",
+        "payload": "",
+        "timestamp": "2021-07-05T12:00:00+02:00",
+        "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJNZXNzYWdlQmlyZCIsIm5iZiI6MTYyNTQ3OTIwMCwiZXhwIjoxNjI1NDc5MjYwLCJqdGkiOiIxNDUwMTUzMi05NmYyLTQ2ODQtOTgzMi02OGYwOTUxYWUzNDIiLCJ1cmxfaGFzaCI6IjBmMTE1ZGIwNjJiN2MwZGQwMzBiMTY4NzhjOTlkZWE1YzM1NGI0OWRjMzdiMzhlYjg4NDYxNzljNzc4M2U5ZDciLCJwYXlsb2FkX2hhc2giOiJkZmZkNjAyMWJiMmJkNWIwYWY2NzYyOTA4MDllYzNhNTMxOTFkZDgxYzdmNzBhNGIyODY4OGEzNjIxODI5ODZmIn0.bHfsjj3tljfzTufoG3EU3p_yFrQh9CufyzRSaRMd4ss",
+        "valid": false,
+        "reason": "invalid jwt: claim payload_hash is set but actual payload is missing"
+    },
+    {
+        "name": "payload was added in transit - DELETE",
+        "method": "DELETE",
+        "secret": "36efdd1aace2e26cd490f0d951138253bef2f7c6d34d18981da781555cc4cebb",
+        "url": "https://example.com/",
+        "payload": "Hello, World!",
+        "timestamp": "2021-07-05T12:00:00+02:00",
+        "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJNZXNzYWdlQmlyZCIsIm5iZiI6MTYyNTQ3OTIwMCwiZXhwIjoxNjI1NDc5MjYwLCJqdGkiOiI1OWEyNDRkYy1lOWFkLTRlMjMtOTc3OC0zNzFmYWEyMzhmNzIiLCJ1cmxfaGFzaCI6IjBmMTE1ZGIwNjJiN2MwZGQwMzBiMTY4NzhjOTlkZWE1YzM1NGI0OWRjMzdiMzhlYjg4NDYxNzljNzc4M2U5ZDcifQ.6Fp0rVOsRr1fj9S2GidXAfkmPVofKr8_RTffC6G6r2E",
+        "valid": false,
+        "reason": "invalid jwt: claim payload_hash is not set but payload is present"
+    },
+    {
+        "name": "payload was added in transit - GET",
+        "method": "GET",
+        "secret": "36efdd1aace2e26cd490f0d951138253bef2f7c6d34d18981da781555cc4cebb",
+        "url": "https://example.com/",
+        "payload": "Hello, World!",
+        "timestamp": "2021-07-05T12:00:00+02:00",
+        "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJNZXNzYWdlQmlyZCIsIm5iZiI6MTYyNTQ3OTIwMCwiZXhwIjoxNjI1NDc5MjYwLCJqdGkiOiI1OWEyNDRkYy1lOWFkLTRlMjMtOTc3OC0zNzFmYWEyMzhmNzIiLCJ1cmxfaGFzaCI6IjBmMTE1ZGIwNjJiN2MwZGQwMzBiMTY4NzhjOTlkZWE1YzM1NGI0OWRjMzdiMzhlYjg4NDYxNzljNzc4M2U5ZDcifQ.6Fp0rVOsRr1fj9S2GidXAfkmPVofKr8_RTffC6G6r2E",
+        "valid": false,
+        "reason": "invalid jwt: claim payload_hash is not set but payload is present"
+    },
+    {
+        "name": "payload was added in transit - PATCH",
+        "method": "PATCH",
+        "secret": "36efdd1aace2e26cd490f0d951138253bef2f7c6d34d18981da781555cc4cebb",
+        "url": "https://example.com/",
+        "payload": "Hello, World!",
+        "timestamp": "2021-07-05T12:00:00+02:00",
+        "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJNZXNzYWdlQmlyZCIsIm5iZiI6MTYyNTQ3OTIwMCwiZXhwIjoxNjI1NDc5MjYwLCJqdGkiOiI1OWEyNDRkYy1lOWFkLTRlMjMtOTc3OC0zNzFmYWEyMzhmNzIiLCJ1cmxfaGFzaCI6IjBmMTE1ZGIwNjJiN2MwZGQwMzBiMTY4NzhjOTlkZWE1YzM1NGI0OWRjMzdiMzhlYjg4NDYxNzljNzc4M2U5ZDcifQ.6Fp0rVOsRr1fj9S2GidXAfkmPVofKr8_RTffC6G6r2E",
+        "valid": false,
+        "reason": "invalid jwt: claim payload_hash is not set but payload is present"
+    },
+    {
+        "name": "payload was added in transit - POST",
+        "method": "POST",
+        "secret": "36efdd1aace2e26cd490f0d951138253bef2f7c6d34d18981da781555cc4cebb",
+        "url": "https://example.com/",
+        "payload": "Hello, World!",
+        "timestamp": "2021-07-05T12:00:00+02:00",
+        "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJNZXNzYWdlQmlyZCIsIm5iZiI6MTYyNTQ3OTIwMCwiZXhwIjoxNjI1NDc5MjYwLCJqdGkiOiI1OWEyNDRkYy1lOWFkLTRlMjMtOTc3OC0zNzFmYWEyMzhmNzIiLCJ1cmxfaGFzaCI6IjBmMTE1ZGIwNjJiN2MwZGQwMzBiMTY4NzhjOTlkZWE1YzM1NGI0OWRjMzdiMzhlYjg4NDYxNzljNzc4M2U5ZDcifQ.6Fp0rVOsRr1fj9S2GidXAfkmPVofKr8_RTffC6G6r2E",
+        "valid": false,
+        "reason": "invalid jwt: claim payload_hash is not set but payload is present"
+    },
+    {
+        "name": "payload was added in transit - PUT",
+        "method": "PUT",
+        "secret": "36efdd1aace2e26cd490f0d951138253bef2f7c6d34d18981da781555cc4cebb",
+        "url": "https://example.com/",
+        "payload": "Hello, World!",
+        "timestamp": "2021-07-05T12:00:00+02:00",
+        "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJNZXNzYWdlQmlyZCIsIm5iZiI6MTYyNTQ3OTIwMCwiZXhwIjoxNjI1NDc5MjYwLCJqdGkiOiI1OWEyNDRkYy1lOWFkLTRlMjMtOTc3OC0zNzFmYWEyMzhmNzIiLCJ1cmxfaGFzaCI6IjBmMTE1ZGIwNjJiN2MwZGQwMzBiMTY4NzhjOTlkZWE1YzM1NGI0OWRjMzdiMzhlYjg4NDYxNzljNzc4M2U5ZDcifQ.6Fp0rVOsRr1fj9S2GidXAfkmPVofKr8_RTffC6G6r2E",
+        "valid": false,
+        "reason": "invalid jwt: claim payload_hash is not set but payload is present"
+    },
+    {
+        "name": "Port number in URL - GET",
+        "method": "GET",
+        "secret": "36efdd1aace2e26cd490f0d951138253bef2f7c6d34d18981da781555cc4cebb",
+        "url": "https://example.com:8080/",
+        "timestamp": "2021-07-05T12:00:00+02:00",
+        "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJNZXNzYWdlQmlyZCIsIm5iZiI6MTYyNTQ3OTIwMCwiZXhwIjoxNjI1NDc5MjYwLCJqdGkiOiI1OWEyNDRkYy1lOWFkLTRlMjMtOTc3OC0zNzFmYWEyMzhmNzIiLCJ1cmxfaGFzaCI6IjA3Zjc4NjFhNjliMTNjMjI5YzZhZTU5NmQxOThiMjc2M2IwNTRjZjVlMDAwZDczNmQxYzQ4MTAyZDc3MGNmZmMifQ.vcpa0IicGAbpo064dOjiA2VbVOR2S5uZBEaBOP16sS8",
+        "valid": true
+    },
+    {
+        "name": "Special characters in URL - GET",
+        "method": "GET",
+        "secret": "36efdd1aace2e26cd490f0d951138253bef2f7c6d34d18981da781555cc4cebb",
+        "url": "https://example.com/?obj%5Bfield1%5D=val1\u0026obj%5Bfield2%5D=val2\u0026param=value+with+spaces",
+        "timestamp": "2021-07-05T12:00:00+02:00",
+        "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJNZXNzYWdlQmlyZCIsIm5iZiI6MTYyNTQ3OTIwMCwiZXhwIjoxNjI1NDc5MjYwLCJqdGkiOiI1OWEyNDRkYy1lOWFkLTRlMjMtOTc3OC0zNzFmYWEyMzhmNzIiLCJ1cmxfaGFzaCI6IjhhZmYzNzQ4ZDc4OWM0MzMzNTczZTFjMzFmZTViMDA0OTQwY2I1ZmM0NzQ2MGVkM2QwZTY1NGY3ZmM0ZTVmYWUifQ.mJBCMfEjKmN3IMuzqPXPHktWETrcu0iNdF3agE8PDyI",
+        "valid": true
+    },
+    {
+        "name": "Special characters in the payload - DELETE",
+        "method": "DELETE",
+        "secret": "36efdd1aace2e26cd490f0d951138253bef2f7c6d34d18981da781555cc4cebb",
+        "url": "https://example.com/",
+        "payload": "Some text containg \u0026 \u003c \u003e, \u0026 and \\u0026",
+        "timestamp": "2021-07-05T12:00:00+02:00",
+        "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJNZXNzYWdlQmlyZCIsIm5iZiI6MTYyNTQ3OTIwMCwiZXhwIjoxNjI1NDc5MjYwLCJqdGkiOiI1OWEyNDRkYy1lOWFkLTRlMjMtOTc3OC0zNzFmYWEyMzhmNzIiLCJ1cmxfaGFzaCI6IjBmMTE1ZGIwNjJiN2MwZGQwMzBiMTY4NzhjOTlkZWE1YzM1NGI0OWRjMzdiMzhlYjg4NDYxNzljNzc4M2U5ZDciLCJwYXlsb2FkX2hhc2giOiIyNDMxYmQ5Y2NiNDhlZDAxNmZhZDU2N2IwNzcxMjAzOGI1Y2RkOTQ5YWM5ZDQxZmU0NjkzZDVhMzg0NWNmN2U4In0.IQiKzeEPaO3A48lhKmBDSmxZyCESPCGxdSKFdi0dEJs",
+        "valid": true
+    },
+    {
+        "name": "Special characters in the payload - GET",
+        "method": "GET",
+        "secret": "36efdd1aace2e26cd490f0d951138253bef2f7c6d34d18981da781555cc4cebb",
+        "url": "https://example.com/",
+        "payload": "Some text containg \u0026 \u003c \u003e, \u0026 and \\u0026",
+        "timestamp": "2021-07-05T12:00:00+02:00",
+        "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJNZXNzYWdlQmlyZCIsIm5iZiI6MTYyNTQ3OTIwMCwiZXhwIjoxNjI1NDc5MjYwLCJqdGkiOiI1OWEyNDRkYy1lOWFkLTRlMjMtOTc3OC0zNzFmYWEyMzhmNzIiLCJ1cmxfaGFzaCI6IjBmMTE1ZGIwNjJiN2MwZGQwMzBiMTY4NzhjOTlkZWE1YzM1NGI0OWRjMzdiMzhlYjg4NDYxNzljNzc4M2U5ZDciLCJwYXlsb2FkX2hhc2giOiIyNDMxYmQ5Y2NiNDhlZDAxNmZhZDU2N2IwNzcxMjAzOGI1Y2RkOTQ5YWM5ZDQxZmU0NjkzZDVhMzg0NWNmN2U4In0.IQiKzeEPaO3A48lhKmBDSmxZyCESPCGxdSKFdi0dEJs",
+        "valid": true
+    },
+    {
+        "name": "Special characters in the payload - PATCH",
+        "method": "PATCH",
+        "secret": "36efdd1aace2e26cd490f0d951138253bef2f7c6d34d18981da781555cc4cebb",
+        "url": "https://example.com/",
+        "payload": "Some text containg \u0026 \u003c \u003e, \u0026 and \\u0026",
+        "timestamp": "2021-07-05T12:00:00+02:00",
+        "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJNZXNzYWdlQmlyZCIsIm5iZiI6MTYyNTQ3OTIwMCwiZXhwIjoxNjI1NDc5MjYwLCJqdGkiOiI1OWEyNDRkYy1lOWFkLTRlMjMtOTc3OC0zNzFmYWEyMzhmNzIiLCJ1cmxfaGFzaCI6IjBmMTE1ZGIwNjJiN2MwZGQwMzBiMTY4NzhjOTlkZWE1YzM1NGI0OWRjMzdiMzhlYjg4NDYxNzljNzc4M2U5ZDciLCJwYXlsb2FkX2hhc2giOiIyNDMxYmQ5Y2NiNDhlZDAxNmZhZDU2N2IwNzcxMjAzOGI1Y2RkOTQ5YWM5ZDQxZmU0NjkzZDVhMzg0NWNmN2U4In0.IQiKzeEPaO3A48lhKmBDSmxZyCESPCGxdSKFdi0dEJs",
+        "valid": true
+    },
+    {
+        "name": "Special characters in the payload - POST",
+        "method": "POST",
+        "secret": "36efdd1aace2e26cd490f0d951138253bef2f7c6d34d18981da781555cc4cebb",
+        "url": "https://example.com/",
+        "payload": "Some text containg \u0026 \u003c \u003e, \u0026 and \\u0026",
+        "timestamp": "2021-07-05T12:00:00+02:00",
+        "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJNZXNzYWdlQmlyZCIsIm5iZiI6MTYyNTQ3OTIwMCwiZXhwIjoxNjI1NDc5MjYwLCJqdGkiOiI1OWEyNDRkYy1lOWFkLTRlMjMtOTc3OC0zNzFmYWEyMzhmNzIiLCJ1cmxfaGFzaCI6IjBmMTE1ZGIwNjJiN2MwZGQwMzBiMTY4NzhjOTlkZWE1YzM1NGI0OWRjMzdiMzhlYjg4NDYxNzljNzc4M2U5ZDciLCJwYXlsb2FkX2hhc2giOiIyNDMxYmQ5Y2NiNDhlZDAxNmZhZDU2N2IwNzcxMjAzOGI1Y2RkOTQ5YWM5ZDQxZmU0NjkzZDVhMzg0NWNmN2U4In0.IQiKzeEPaO3A48lhKmBDSmxZyCESPCGxdSKFdi0dEJs",
+        "valid": true
+    },
+    {
+        "name": "Special characters in the payload - PUT",
+        "method": "PUT",
+        "secret": "36efdd1aace2e26cd490f0d951138253bef2f7c6d34d18981da781555cc4cebb",
+        "url": "https://example.com/",
+        "payload": "Some text containg \u0026 \u003c \u003e, \u0026 and \\u0026",
+        "timestamp": "2021-07-05T12:00:00+02:00",
+        "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJNZXNzYWdlQmlyZCIsIm5iZiI6MTYyNTQ3OTIwMCwiZXhwIjoxNjI1NDc5MjYwLCJqdGkiOiI1OWEyNDRkYy1lOWFkLTRlMjMtOTc3OC0zNzFmYWEyMzhmNzIiLCJ1cmxfaGFzaCI6IjBmMTE1ZGIwNjJiN2MwZGQwMzBiMTY4NzhjOTlkZWE1YzM1NGI0OWRjMzdiMzhlYjg4NDYxNzljNzc4M2U5ZDciLCJwYXlsb2FkX2hhc2giOiIyNDMxYmQ5Y2NiNDhlZDAxNmZhZDU2N2IwNzcxMjAzOGI1Y2RkOTQ5YWM5ZDQxZmU0NjkzZDVhMzg0NWNmN2U4In0.IQiKzeEPaO3A48lhKmBDSmxZyCESPCGxdSKFdi0dEJs",
+        "valid": true
+    },
+    {
+        "name": "HS384 alg - GET",
+        "method": "GET",
+        "secret": "36efdd1aace2e26cd490f0d951138253bef2f7c6d34d18981da781555cc4cebb",
+        "url": "https://example.com/",
+        "timestamp": "2021-07-05T12:00:00+02:00",
+        "token": "eyJhbGciOiJIUzM4NCIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJNZXNzYWdlQmlyZCIsIm5iZiI6MTYyNTQ3OTIwMCwiZXhwIjoxNjI1NDc5MjYwLCJqdGkiOiI1OWEyNDRkYy1lOWFkLTRlMjMtOTc3OC0zNzFmYWEyMzhmNzIiLCJ1cmxfaGFzaCI6IjBmMTE1ZGIwNjJiN2MwZGQwMzBiMTY4NzhjOTlkZWE1YzM1NGI0OWRjMzdiMzhlYjg4NDYxNzljNzc4M2U5ZDcifQ.KNMW-29X77lZeuPmThmHWc_RUAvTkaDkpxIZK6mqE08v8mWKiU9Edh4QXwAJO2nv",
+        "valid": true
+    },
+    {
+        "name": "HS512 alg - GET",
+        "method": "GET",
+        "secret": "36efdd1aace2e26cd490f0d951138253bef2f7c6d34d18981da781555cc4cebb",
+        "url": "https://example.com/",
+        "timestamp": "2021-07-05T12:00:00+02:00",
+        "token": "eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJNZXNzYWdlQmlyZCIsIm5iZiI6MTYyNTQ3OTIwMCwiZXhwIjoxNjI1NDc5MjYwLCJqdGkiOiI1OWEyNDRkYy1lOWFkLTRlMjMtOTc3OC0zNzFmYWEyMzhmNzIiLCJ1cmxfaGFzaCI6IjBmMTE1ZGIwNjJiN2MwZGQwMzBiMTY4NzhjOTlkZWE1YzM1NGI0OWRjMzdiMzhlYjg4NDYxNzljNzc4M2U5ZDcifQ.rd6r0iMyNGnVPCwurETphE3Y8rpAyvvnUK0S8WvGUkt2E1QSRAZ7NZJZBHw1Y_Wb5W-sK9HJr_PRL2vz4jRT3Q",
+        "valid": true
+    },
+    {
+        "name": "none alg - GET",
+        "method": "GET",
+        "url": "https://example.com/",
+        "timestamp": "2021-07-05T12:00:00+02:00",
+        "token": "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJpc3MiOiJNZXNzYWdlQmlyZCIsImlhdCI6MTYyNTQ3OTIwMCwiZXhwIjoxNjI1NDc5MjYwLCJqdGkiOiI1OWEyNDRkYy1lOWFkLTRlMjMtOTc3OC0zNzFmYWEyMzhmNzIiLCJ1cmxfaGFzaCI6IjBmMTE1ZGIwNjJiN2MwZGQwMzBiMTY4NzhjOTlkZWE1YzM1NGI0OWRjMzdiMzhlYjg4NDYxNzljNzc4M2U5ZDcifQ.",
+        "valid": false,
+        "reason": "invalid jwt: signing method none is invalid"
+    }
+]


### PR DESCRIPTION
This PR adds support for the new webhook signature method. More info about it here: [Verify HTTP Request](https://developers.messagebird.com/docs/verify-http-requests)

In short, the PR deprecates the older webhook signature method with the request headers: `MessageBird-Signature` and `MessageBird-Request-Timestamp`. 

The new official request signature method is supported. It is signed and sent with `MessageBird-Signature-JWT` header.